### PR TITLE
Fix: Monaco loader not available

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MominAI</title>
     <link rel="icon" href="/assets/logo.svg" type="image/svg+xml">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.33.0/min/vs/loader.min.js"></script>
 
         <style>
         :root {


### PR DESCRIPTION
The Monaco editor was failing to load because the loader script was not included in the `index.html` file. This change adds the Monaco loader script from a CDN to the `<head>` of `index.html`, which makes the Monaco editor available to the application.